### PR TITLE
Restyle radio select buttons

### DIFF
--- a/client/presentations/color-selector-button.jsx
+++ b/client/presentations/color-selector-button.jsx
@@ -5,16 +5,23 @@ import React from 'react';
 const ColorSelector = function(props) {
   let name      = `${props.type}Color`;
   let className = props.selected ? 'selected button' : 'neutral button';
-  let radio;
+  let labelElement;
 
-  let onLabelFocus = (event) => {
-    console.log('label focused!', radio);
-    radio.focus();
+  let onFocus = (event) => {
+    labelElement.className += ' focused';
   };
 
+  let onBlur = (event) => {
+    labelElement.className = labelElement.className.replace(' focused', '');
+  }
+
   return (
-    <div className='color-selector unit relative'>
-      <div className='radio-control off-screen'>
+    <label
+      className='radio-selector unit relative'
+      htmlFor={props.color}
+      ref={ (element) => { return labelElement = element; } }
+    >
+      <div className='off-screen'>
         <input
           type='radio'
           name={name}
@@ -22,21 +29,17 @@ const ColorSelector = function(props) {
           value={props.color}
           checked={props.selected}
           onChange={props.onChange}
-          ref={(input) => { radio = input; }}
+          tabIndex={props.tabIndex}
+          onFocus={onFocus}
+          onBlur={onBlur}
         />
       </div>
       <div className='unit shadow-container'>
-        <label
-          className={className}
-          htmlFor={props.color}
-          tabIndex={props.tabIndex}
-          onFocus={onLabelFocus}
-        >
+        <div className={className}>
           {props.color}
-        </label>
+        </div>
       </div>
-      <div className='unit spacer'></div>
-    </div>
+    </label>
   );
 };
 

--- a/client/presentations/color-selector-button.jsx
+++ b/client/presentations/color-selector-button.jsx
@@ -2,29 +2,38 @@
 
 import React from 'react';
 
-const selectedCSS = (propValue, selectedValue) => {
-  return propValue === selectedValue ? 'selected' : 'neutral';
-};
-
 const ColorSelector = function(props) {
-  let name = `${props.type}Color`;
-  let className = selectedCSS(props.currentColor, props.color);
-  let ariaChecked = className == 'selected' ? 'true' : 'false';
+  let name      = `${props.type}Color`;
+  let className = props.selected ? 'selected button' : 'neutral button';
+  let radio;
+
+  let onLabelFocus = (event) => {
+    console.log('label focused!', radio);
+    radio.focus();
+  };
 
   return (
-    <div className='color-selector'>
-      <div key={props.color} className='unit'>
-        <div className='shadow-container'>
-          <button
-              role="radio"
-              aria-checked={ariaChecked}
-              name={name}
-              value={props.color}
-              onClick={props.onClick}
-              className={className}>
-            {props.color}
-          </button>
-        </div>
+    <div className='color-selector unit relative'>
+      <div className='radio-control off-screen'>
+        <input
+          type='radio'
+          name={name}
+          id={props.color}
+          value={props.color}
+          checked={props.selected}
+          onChange={props.onChange}
+          ref={(input) => { radio = input; }}
+        />
+      </div>
+      <div className='unit shadow-container'>
+        <label
+          className={className}
+          htmlFor={props.color}
+          tabIndex={props.tabIndex}
+          onFocus={onLabelFocus}
+        >
+          {props.color}
+        </label>
       </div>
       <div className='unit spacer'></div>
     </div>

--- a/client/presentations/color-selector-button.jsx
+++ b/client/presentations/color-selector-button.jsx
@@ -3,16 +3,17 @@
 import React from 'react';
 
 const ColorSelector = function(props) {
-  let name      = `${props.type}Color`;
+  const name = `${props.type}Color`;
+  const focusedClass = ' focused';
   let className = props.selected ? 'selected button' : 'neutral button';
   let labelElement;
 
   let onFocus = (event) => {
-    labelElement.className += ' focused';
+    labelElement.className += focusedClass;
   };
 
   let onBlur = (event) => {
-    labelElement.className = labelElement.className.replace(' focused', '');
+    labelElement.className = labelElement.className.replace(focusedClass, '');
   }
 
   return (

--- a/client/presentations/color-selectors-collection.jsx
+++ b/client/presentations/color-selectors-collection.jsx
@@ -8,22 +8,27 @@ const HairColorSelector = (props) => {
   let currentColor = props.state[typeName];
 
   let colorButtons = props.colors.map((color) => {
+    let tabIndex = '-1';
+    let selected = (currentColor === color);
+    if (selected || (!currentColor && color === props.colors[0]) ) {
+      tabIndex = '0';
+    }
+
     return (
       <ColorSelectorButton
         key={color}
         type={props.type}
         color={color}
-        currentColor={currentColor}
-        onClick={props.onChange}
+        selected={selected}
+        onChange={props.onChange}
+        tabIndex={tabIndex}
       />
     );
   });
 
   return (
-    <div className='row selector-collection'
-      role='radiogroup'
-      aria-labelledby={typeName}>
-        { colorButtons }
+    <div className='row selector-collection'>
+      { colorButtons }
     </div>
   );
 }

--- a/client/presentations/color-selectors-collection.jsx
+++ b/client/presentations/color-selectors-collection.jsx
@@ -15,14 +15,16 @@ const HairColorSelector = (props) => {
     }
 
     return (
-      <ColorSelectorButton
-        key={color}
-        type={props.type}
-        color={color}
-        selected={selected}
-        onChange={props.onChange}
-        tabIndex={tabIndex}
-      />
+      <div key={color}>
+        <ColorSelectorButton
+          type={props.type}
+          color={color}
+          selected={selected}
+          onChange={props.onChange}
+          tabIndex={tabIndex}
+        />
+        <div className='unit spacer'></div>
+      </div>
     );
   });
 

--- a/client/stylesheets/mobile/_oo-styles.scss
+++ b/client/stylesheets/mobile/_oo-styles.scss
@@ -22,6 +22,11 @@
   position: relative;
 }
 
+.off-screen {
+  position: absolute;
+  left: -999px;
+}
+
 
 
 .inner-top {

--- a/client/stylesheets/mobile/widgets/_buttons.scss
+++ b/client/stylesheets/mobile/widgets/_buttons.scss
@@ -37,9 +37,8 @@ label.button {
   }
 
   &:focus {
-    text-decoration: underline;
     background-color: $accent-light;
-    @include box-shadow($primary-dark $shadow-padding/2 $shadow-padding/2 $shadow-padding);
+    @include button-focused;
   }
 
   &:active {
@@ -137,5 +136,14 @@ label.button {
 
   &.disabled {
     @include opacity(0.3);
+  }
+}
+
+label.focused {
+  button,
+  input[type=submit],
+  a.button,
+  div.button {
+    @include button-focused;
   }
 }

--- a/client/stylesheets/variables/_mixins.scss
+++ b/client/stylesheets/variables/_mixins.scss
@@ -34,6 +34,11 @@
   @include transition-duration(500ms);
 }
 
+@mixin button-focused {
+  text-decoration: underline;
+  @include box-shadow($primary-dark $shadow-padding/2 $shadow-padding/2 $shadow-padding);
+}
+
 /* form input fixes */
 @mixin focus-input-padding-fix {
   padding: $input-top-padding - $input-border-width $input-side-padding - $input-border-width;

--- a/test/features/step_definitions/eye-color-selection-steps.js
+++ b/test/features/step_definitions/eye-color-selection-steps.js
@@ -7,15 +7,15 @@ module.exports = function (world) {
 
   world.then('I will see buttons for Blue, Gray, Green, Hazel and Brown', function(done) {
     browser
-      .html('button[value="Blue"]')
+      .html('label[for="Blue"]')
       .then((button) => { assert.ok(button, 'Selector for Blue eye color missing')})
-      .html('button[value="Gray"]')
+      .html('label[for="Gray"]')
       .then((button) => { assert.ok(button, 'Selector for Gray eye color missing')})
-      .html('button[value="Green"]')
+      .html('label[for="Green"]')
       .then((button) => { assert.ok(button, 'Selector for Green eye color missing')})
-      .html('button[value="Hazel"]')
+      .html('label[for="Hazel"]')
       .then((button) => { assert.ok(button, 'Selector for Hazel eye color missing')})
-      .html('button[value="Brown"]')
+      .html('label[for="Brown"]')
       .then((button) => { assert.ok(button, 'Selector for Brown eye color missing')})
       .then(() => { done(); })
       .catch(done);
@@ -24,7 +24,7 @@ module.exports = function (world) {
   world.given('I have already entered my eye color into the form', function(done){
     browser
       .click('a.appearance-eye')
-      .click('button[value="Hazel"]')
+      .click('label[for="Hazel"]')
       .click('input[type="submit"]')
       .click('a.home')
       .waitForSelector('.home-page')
@@ -44,39 +44,45 @@ module.exports = function (world) {
 
   world.when('I select an eye color', function(done){
     browser
-      .click('button[value="Blue"]')
+      .click('label[for="Blue"]')
       .then(() => { done(); })
       .catch(done);
   });
 
   world.and('I see that eye color selected', function(done){
-    // currently a no-op, since this set of commits was spawned by a huge
-    // overhaul of this section
-    done();
+    browser
+      .text('.button.selected')
+      .then((color) => { assert.equal(color, 'Blue'); })
+      .then(() => { done(); })
+      .catch(done);
   });
 
   world.and('I realize I made the wrong eye color selection and change it', function(done){
     browser
-      .click('button[value="Brown"]')
+      .click('label[for="Brown"]')
       .then(() => { done(); })
       .catch(done);
   });
 
   world.then('I will see the original eye color selection as not highlighted', function(done){
-    // currently a no-op, since this set of commits was spawned by a huge
-    // overhaul of this section
-    done();
+    browser
+      .text('.button.selected')
+      .then((color) => { assert.ok(color !== 'Blue', 'Original color still selected'); })
+      .then(() => { done(); })
+      .catch(done);
   });
 
   world.and('I will see the new eye color selection has been highlighted', function(done){
-    // currently a no-op, since this set of commits was spawned by a huge
-    // overhaul of this section
-    done();
+    browser
+      .text('.button.selected')
+      .then((color) => { assert.equal(color, 'Brown'); })
+      .then(() => { done(); })
+      .catch(done);
   });
 
   world.and('I change my eye color selection', function(done){
     browser
-      .click('button[value="Gray"]')
+      .click('label[for="Gray"]')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/hair-color-steps.js
+++ b/test/features/step_definitions/hair-color-steps.js
@@ -7,23 +7,23 @@ module.exports = function (world) {
 
   world.then('I will see buttons for Auburn, Bald, Black, Blonde, Brown, Gray, Red, White and Other', function (done) {
     browser
-      .html('button[value="Auburn"]')
+      .html('label[for="Auburn"]')
       .then((button) => { assert.ok(button, 'Selector for Auburn hair color missing')})
-      .html('button[value="Bald"]')
+      .html('label[for="Bald"]')
       .then((button) => { assert.ok(button, 'Selector for Bald hair color missing')})
-      .html('button[value="Black"]')
+      .html('label[for="Black"]')
       .then((button) => { assert.ok(button, 'Selector for Black hair color missing')})
-      .html('button[value="Blonde"]')
+      .html('label[for="Blonde"]')
       .then((button) => { assert.ok(button, 'Selector for Blonde hair color missing')})
-      .html('button[value="Brown"]')
+      .html('label[for="Brown"]')
       .then((button) => { assert.ok(button, 'Selector for Brown hair color missing')})
-      .html('button[value="Gray"]')
+      .html('label[for="Gray"]')
       .then((button) => { assert.ok(button, 'Selector for Gray hair color missing')})
-      .html('button[value="Red"]')
+      .html('label[for="Red"]')
       .then((button) => { assert.ok(button, 'Selector for Red hair color missing')})
-      .html('button[value="White"]')
+      .html('label[for="White"]')
       .then((button) => { assert.ok(button, 'Selector for White hair color missing')})
-      .html('button[value="Other"]')
+      .html('label[for="Other"]')
       .then((button) => { assert.ok(button, 'Selector for Other hair color missing')})
       .then(() => { done(); })
       .catch(done);
@@ -31,7 +31,7 @@ module.exports = function (world) {
 
   world.and('I select a hair color', function (done) {
     browser
-      .click('button[value="Auburn"]')
+      .click('label[for="Auburn"]')
       .then(() => { done(); })
       .catch(done);
   });
@@ -50,7 +50,7 @@ module.exports = function (world) {
     browser
       .click('a.appearance-hair')
       .waitForSelector('.hair-color-form')
-      .click('button[value="Auburn"]')
+      .click('label[for="Auburn"]')
       .click('input[type="submit"]')
       .click('a.home')
       .waitForSelector('.home-page')
@@ -59,46 +59,54 @@ module.exports = function (world) {
   });
 
   world.then('I will see the hair color I selected', function (done) {
-    // currently a no-op, since this set of commits was spawned by a huge
-    // overhaul of this section
-    done();
+    browser
+      .text('.button.selected')
+      .then((color) => { assert.equal(color, 'Auburn'); })
+      .then(() => { done(); })
+      .catch(done);
   });
 
   world.and('I select another hair color', function (done) {
     browser
-      .click('button[value="Red"]')
+      .click('label[for="Red"]')
       .then(() => { done(); })
       .catch(done);
   });
 
   world.and('I see that color selected', function (done) {
-    // currently a no-op, since this set of commits was spawned by a huge
-    // overhaul of this section
-    done();
+    browser
+      .text('.button.selected')
+      .then((color) => { assert.equal(color, 'Red'); })
+      .then(() => { done(); })
+      .catch(done);
   });
 
   world.and('I realize I made the wrong selection and change it', function (done) {
     browser
-      .click('button[value="Other"]')
+      .click('label[for="Other"]')
       .then(() => { done(); })
       .catch(done);
   });
 
   world.then('I will see the original selection as not highlighted', function (done) {
-    // currently a no-op, since this set of commits was spawned by a huge
-    // overhaul of this section
-    done();
+    browser
+      .text('.button.selected')
+      .then((color) => { assert.ok(color !== 'Red', 'Original color selected'); })
+      .then(() => { done(); })
+      .catch(done);
   });
 
   world.and('I will see the new selection has been highlighted', function (done) {
-    // currently a no-op, since this set of commits was spawned by a huge
-    // overhaul of this section
-    done();
+    browser
+      .text('.button.selected')
+      .then((color) => { assert.equal(color, 'Other'); })
+      .then(() => { done(); })
+      .catch(done);
   });
 
   world.and('I change my hair color selection', function (done) {
     browser
-      .click('button[value="Bald"]')
+      .click('label[for="Bald"]')
       .then(() => { done(); })
       .catch(done);
   });


### PR DESCRIPTION
These commits finally gets the radio buttons styled so that it is clear
visually and consistent behaviorally with existing keyboard radio button
accessibility.

There is something a bit janky about the implementation of the focus
styling currently. What we will probably need is a section of the data
store that is for UI state as opposed to the domain state which is all
we are currently storing. If we put the selector-focus in UI state, then
this flow would not involve saving a ref to the label and manually
changing styling. I think it is a bigger haul though to get to that
point.

One other thing to note, we are going to need to genericize this as more
features come out that have selectors. Currently, these selectors are
tied to color selection, so we will need to do some work to abstract
this a little as soon as we have a different use case!