### PR TITLE
Changes the old default title to something more comprehensible

### DIFF
--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Substrate - Express, React and SCSS for CA</title>
+    <title>DMV - Online ID and License Application</title>
     <meta name="viewport" content="initial-scale=1">
     <link href="/favicon.ico" rel="shortcut icon" type="image/ico">
     <link rel="stylesheet" href="/app.css">


### PR DESCRIPTION
The old application page title had something taken from the goldrush library that was out of date and not relevant to this application. I changed it because it bothered me ...

That's all.

We have a story upcoming for making the title dynamic, but that is not addressed at all here.