### PR TITLE
[Finishes #150487499] Updates styling for input containers

### DIFF
--- a/client/stylesheets/mobile/widgets/_form-elements.scss
+++ b/client/stylesheets/mobile/widgets/_form-elements.scss
@@ -1,7 +1,7 @@
 .input-container {
-  margin-top: $input-top-padding + $input-border-width + $shadow-padding/2;
+  margin-top: $input-top-padding + $input-border-width + ceil($shadow-padding/2);
   margin-bottom: $input-top-padding;
-  margin-right: $input-side-padding $shadow-padding/2;
+  margin-right: $input-side-padding + ceil($shadow-padding/2);
   margin-left: $input-side-padding;
 }
 


### PR DESCRIPTION
There was a bug in the input styling where a + sign was missing in the
SASS math that calculated the margin required to align text inputs.
Also, since 1/2 pixels are not so good, I added some ceiling to the
calculations.

This affected the story for collection of date of birth, in mobile mode.