### PR TITLE
Fixes copy-paste mistake with the headline for the weight form

### DIFF
--- a/client/presentations/weight-form.jsx
+++ b/client/presentations/weight-form.jsx
@@ -11,7 +11,7 @@ const Form = (props) => {
     <div className='weight-form'>
       <HomeLink />
 
-      <h4>How tall are you?</h4>
+      <h4>And how much do you weigh?</h4>
       <h5>Example: 190 pounds</h5>
 
       <form onSubmit={ props.onSubmit }>


### PR DESCRIPTION
I was working too fast and loose. This is the fix for the title of the weight form, which I copied from the height form and didn't change.