### PR TITLE
Fixes issues with focused inputs, so they work!

### DIFF
--- a/client/stylesheets/mobile/widgets/_form-elements.scss
+++ b/client/stylesheets/mobile/widgets/_form-elements.scss
@@ -29,6 +29,8 @@ textarea {
   &.focus {
     @include button-focused;
     @include focus-input-padding-fix;
+    color: black;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
The last commit of my restlye did a bit of css refactoring that wasn't caught by automated testing. It included a `focus` mixin into the focused inputs. This had the unfortunate effect of making the text white and underlined.

This commit fixes that so that people can use the app again. While typing works it feels like everything is broken since you can't see the text you are typing. Very disarming! 