### PR TITLE
Redo buttons

### DIFF
--- a/client/stylesheets/app/all.scss
+++ b/client/stylesheets/app/all.scss
@@ -34,57 +34,71 @@ h1.inner {
   }
 }
 
+
+$tap-hover-color:   #0280bb;
+$tap-normal-border: #afafaf;
+$tap-hover-border:  #c5c5c5;
+$tap-active-border: #8c8c8c;
+
 button.tap,
 input[type=submit].tap,
 a.button.tap,
 div.button.tap,
 label.button.tap {
-  padding-top: $spacing * 2;
-  padding-bottom: $spacing * 2;
+  padding-top:      $spacing * 2;
+  padding-bottom:   $spacing * 2;
   background-color: white;
-  border-color: $primary;
-  color: $primary;
+  border-color:     $tap-normal-border;
+  color:            $primary;
 
   &:hover,
   &.hover {
-    background-color: $sky-blue;
-  }
-
-  &:focus,
-  &.focus {
-    @include button-focused;
-    color: $primary;
+    border-color: $tap-hover-border;
+    color: $tap-hover-color;
   }
 
   &:active,
   &.active {
-    background-color: $sky-blue;
-    border-color: $highlight;
+    border-color: $tap-active-border;
   }
 }
+
+.focus {
+  button.tap,
+  input[type=submit].tap,
+  a.button.tap,
+  div.button.tap,
+  label.button.tap {
+    text-decoration-line: underline;
+    text-decoration-color: $highlight;
+    border-color: $highlight;
+
+    &.selected {
+      text-decoration-color: #ef8e1c;
+      border-color: $highlight;
+    }
+  }
+}
+
+$tap-selected-color: #002435;
+$tap-selected-background: #fffef8;
+$tap-selected-hover-background: #fdfbf1;
+$tap-selected-border: #ef8e1c;
 
 button.tap.selected,
 input[type=submit].tap.selected,
 a.button.tap.selected,
 div.button.tap.selected,
 label.button.tap.selected {
-  background-color: $primary;
-  color: $lightest-color;
+  background-color: $tap-selected-background;
+  color: $tap-selected-color;
+  border-color: $tap-selected-border;
 
   &:hover,
-  &.hover {
-    background-color: $med-blue;
-  }
-
-  &:focus,
-  &.focus {
-    @include button-focused;
-  }
-
+  &.hover,
   &:active,
   &.active {
-    background-color: $med-blue;
-    border-color: $highlight;
+    background-color: $tap-selected-hover-background;
   }
 }
 

--- a/client/stylesheets/mobile/widgets/_buttons.scss
+++ b/client/stylesheets/mobile/widgets/_buttons.scss
@@ -3,6 +3,12 @@ input[type=submit] {
   @include line;
 }
 
+$button-active: #016290;
+$button-hover: #004e73;
+$disabled-color: #4e4e4e;
+$disabled-background:  #e8e8e8;
+$disabled-border: #8c8c8c;
+
 button,
 input[type=submit],
 a.button,
@@ -33,19 +39,21 @@ label.button {
 
   &:hover,
   &.hover {
-    background-color: $med-blue;
-    border-color: $med-blue;
+    background-color: $button-hover;
+    border-color: $button-hover;
   }
 
   &:focus,
   &.focus {
-    @include button-focused;
+    text-decoration-line: underline;
+    text-decoration-color: $highlight;
+    border-color: $highlight;
   }
 
   &:active,
   &.active {
-    background-color: $med-blue;
-    border-color: $highlight;
+    background-color: $button-active;
+    border-color: $button-active;
   }
 
   &.disabled,
@@ -56,10 +64,10 @@ label.button {
   &.disabled.hover,
   &.disabled:focus,
   &.disabled:hover {
-    border: $border-width solid $primary;
+    border: $border-width solid $disabled-border;
     padding: $spacing*1.2 - $border-width $spacing*3 - $border-width;
-    background-color: $sky-blue;
-    color: $primary;
+    background-color: $disabled-background;
+    color: $disabled-color;
     text-decoration: none;
   }
 
@@ -149,14 +157,5 @@ label.button {
     &:active {
       background-color: $error-dark;
     }
-  }
-}
-
-label.focused {
-  button,
-  input[type=submit],
-  a.button,
-  div.button {
-    @include button-focused;
   }
 }

--- a/public/styles.html
+++ b/public/styles.html
@@ -140,10 +140,10 @@
                 <div class='button tap'>Normal</div><br>
                 <div class='button tap hover'>Hover</div><br>
                 <div class='button tap active'>Active</div><br>
-                <div class='button tap focus'>Focus</div><br>
+                <span class='focus'><div class='button tap'>Focus</div></span><br>
                 <div class='button tap selected'>Selected</div><br>
                 <div class='button tap selected hover'>Selected hover</div><br>
-                <div class='button tap selected focus'>Selected focused</div>
+                <span class='focus'><div class='button tap selected'>Selected focused</div></span>
               </div>
             </div>
           </form>


### PR DESCRIPTION
The styling for the overhaul story was rejected in part because the select button focus no longer worked and in part because design wasn't happy with the styling. This PR fixes the focus styling and adds on the new button styles provide by design.