### PR TITLE
Makes app flow close to final, without removing links page

### DIFF
--- a/client/containers/routes.jsx
+++ b/client/containers/routes.jsx
@@ -42,9 +42,10 @@ class Router extends React.Component {
   render() {
     return (
       <div className='routes'>
-        <Route path={ alicePath('/') } exact component={Home} />
-        <Route path={ alicePath('/summary') } component={Summary} />
+        <Route path={ alicePath('/') } exact component={Intro} />
         <Route path={ alicePath('/what-do-you-want-to-do-today') } component={Intro} />
+        <Route path={ alicePath('/links') } exact component={Home} />
+        <Route path={ alicePath('/summary') } component={Summary} />
         <Route path={ alicePath('/about-me/legal-name') } component={LegalName} />
         <Route path={ alicePath('/about-me/date-of-birth') } component={DateOfBirth} />
         <Route path={ alicePath('/about-me/home-address') } component={HomeAddress} />

--- a/client/helpers/alice-path.js
+++ b/client/helpers/alice-path.js
@@ -1,5 +1,5 @@
 'use strict';
 
 export default (path) => {
-  return `/services${path}`
+  return `/apply${path}`
 };

--- a/client/presentations/home-link.jsx
+++ b/client/presentations/home-link.jsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import alicePath from '../helpers/alice-path';
 
 const HomeLink = () => {
-  return <Link className='home' to={ alicePath('/') } >Back to application</Link>;
+  return <Link className='sections' to={ alicePath('/links') } tabIndex='-1' >Application sections</Link>;
 };
 
 export default HomeLink;

--- a/client/presentations/home.jsx
+++ b/client/presentations/home.jsx
@@ -54,7 +54,7 @@ const Home = () => {
   });
 
   return (
-    <ul className='home-page'>
+    <ul className='section-links'>
       { listItems }
     </ul>
   );

--- a/client/stylesheets/app/all.scss
+++ b/client/stylesheets/app/all.scss
@@ -94,3 +94,7 @@ label.button.tap.selected {
     width: 100px;
   }
 }
+
+a.sections {
+  color: transparent;
+}

--- a/public/radiator.html
+++ b/public/radiator.html
@@ -108,7 +108,7 @@
           </p>
           <ul class='bullet-list'>
             <li>
-              <h4><a href='https://dlite-web.herokuapp.com/services' target='_blank'>Staging site</a></h4>
+              <h4><a href='https://dlite-web.herokuapp.com/apply' target='_blank'>Staging site</a></h4>
               <p>
                 The staging site automatically deploys.
                 First, developers merge a group of commits into the master branch of our source code.

--- a/server.js
+++ b/server.js
@@ -27,10 +27,10 @@ server.environment  = env.env;
 server.use(express.static('public'));
 
 server.get('/', (req, res) => {
-  res.redirect('/services');
+  res.redirect('/apply/what-do-you-want-to-do-today');
 });
 
-server.get('/services*', (req, res) => {
+server.get('/apply*', (req, res) => {
   res.send(layout);
 });
 

--- a/test/client/helpers/navigate-on-submit-test.js
+++ b/test/client/helpers/navigate-on-submit-test.js
@@ -24,6 +24,6 @@ describe('navigateOnSubmit', function() {
 
   it('pushes an alice url to history', function() {
     navigateOnSubmit('/foo/bar', props)();
-    assert.equal(props.history[0], '/services/foo/bar');
+    assert.equal(props.history[0], '/apply/foo/bar');
   });
 });

--- a/test/features/step_definitions/enter-ballot-language-steps.js
+++ b/test/features/step_definitions/enter-ballot-language-steps.js
@@ -61,8 +61,8 @@ module.exports = function (world) {
       .click('a.ballot-language')
       .click('label[for="Thai"]')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-date-of-birth-steps.js
+++ b/test/features/step_definitions/enter-date-of-birth-steps.js
@@ -43,8 +43,8 @@ module.exports = function(world) {
       .type('#month', '9')
       .type('#day', '7')
       .type('#year', '1967')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-eye-color-steps.js
+++ b/test/features/step_definitions/enter-eye-color-steps.js
@@ -26,8 +26,8 @@ module.exports = function (world) {
       .click('a.eye-color')
       .click('label[for="Blue"]')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-hair-color-steps.js
+++ b/test/features/step_definitions/enter-hair-color-steps.js
@@ -52,8 +52,8 @@ module.exports = function (world) {
       .waitForSelector('.hair-color-form')
       .click('label[for="Auburn"]')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-height-steps.js
+++ b/test/features/step_definitions/enter-height-steps.js
@@ -41,15 +41,13 @@ module.exports = function(world) {
 
   world.given('I have already entered my height into the form', function(done) {
     browser
-      .open(world.url('/'))
-      .waitForSelector('.home-page')
       .click('a.height')
       .waitForSelector('.height-form')
       .type('#feet', '5')
       .type('#inches', '9')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-name-steps.js
+++ b/test/features/step_definitions/enter-name-steps.js
@@ -62,8 +62,6 @@ module.exports = function(world) {
 
   world.given('I have already entered my name into the form', function(done) {
     browser
-      .open(world.url('/'))
-      .waitForSelector('.home-page')
       .click('a.legal-name')
       .waitForSelector('.legal-name-form')
       .type('#firstName', 'FirstName1')
@@ -71,8 +69,8 @@ module.exports = function(world) {
       .type('#lastName', 'LastName1')
       .select('#suffix', '')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-organ-steps.js
+++ b/test/features/step_definitions/enter-organ-steps.js
@@ -62,8 +62,8 @@ module.exports = function(world) {
       .click('a.organ')
       .click('label[for="Yes"]')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-sex-choice-steps.js
+++ b/test/features/step_definitions/enter-sex-choice-steps.js
@@ -46,8 +46,8 @@ module.exports = function(world) {
       .waitForSelector('.sex-form')
       .click('label[for="Female"]')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-social-security-steps.js
+++ b/test/features/step_definitions/enter-social-security-steps.js
@@ -43,8 +43,8 @@ module.exports = function(world) {
       .type('#part1', '123')
       .type('#part2', '45')
       .type('#part3', '1967')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/enter-weight-steps.js
+++ b/test/features/step_definitions/enter-weight-steps.js
@@ -32,14 +32,12 @@ module.exports = function(world) {
 
   world.given('I have already entered my weight into the form', function(done) {
     browser
-      .open(world.url('/'))
-      .waitForSelector('.home-page')
       .click('a.weight')
       .waitForSelector('.weight-form')
       .type('#weight', '210')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/home-address-entry-steps.js
+++ b/test/features/step_definitions/home-address-entry-steps.js
@@ -85,8 +85,8 @@ module.exports = function(world) {
       .select('#homeState', 'CA')
       .type('#homeZip', '94666')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/mailing-address-entry-steps.js
+++ b/test/features/step_definitions/mailing-address-entry-steps.js
@@ -85,8 +85,8 @@ module.exports = function(world) {
       .select('#mailingState', 'CA')
       .type('#mailingZip', '94666')
       .click('input[type="submit"]')
-      .click('a.home')
-      .waitForSelector('.home-page')
+      .click('a.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });

--- a/test/features/step_definitions/navigation-steps.js
+++ b/test/features/step_definitions/navigation-steps.js
@@ -30,7 +30,9 @@ module.exports = function(world) {
   world.given('I go to the new online DL application', function(done) {
     browser
       .open(world.url('/'))
-      .waitForSelector('.home-page')
+      .waitForSelector('.intro-info')
+      .click('.sections')
+      .waitForSelector('.section-links')
       .then(() => { done(); })
       .catch(done);
   });
@@ -40,7 +42,7 @@ module.exports = function(world) {
   });
 
   world.and('I return to the home page', function(done) {
-    clickAndWaitForPage('a.home', '.home-page', done);
+    clickAndWaitForPage('a.sections', '.section-links', done);
   });
 
   world.when('I visit the home addresses page', function(done) {
@@ -144,15 +146,15 @@ module.exports = function(world) {
   });
 
   world.then('I will be on the page for entering my date of birth', function(done) {
-    assertOnPage('.date-of-birth-form', /services\/about-me\/date-of-birth/, done);
+    assertOnPage('.date-of-birth-form', /apply\/about-me\/date-of-birth/, done);
   });
 
   world.then('I will be on the page for entering my home address', function(done) {
-    assertOnPage('.home-address-form', /services\/about-me\/home-address/, done);
+    assertOnPage('.home-address-form', /apply\/about-me\/home-address/, done);
   });
 
   world.then('I will be on the page for entering my mailing address', function(done) {
-    assertOnPage('.mailing-address-form', /services\/about-me\/mailing-address/, done);
+    assertOnPage('.mailing-address-form', /apply\/about-me\/mailing-address/, done);
   });
 
   world.then('I will be on the page for entering my sex identification', function(done) {
@@ -216,7 +218,7 @@ module.exports = function(world) {
   });
 
   world.then('I will be on the page with my summary', function(done) {
-    clickAndWaitForPage('.summary', /services\/summary/, done);
+    clickAndWaitForPage('.summary', /apply\/summary/, done);
   });
 
   world.then('I will be taken to political party page', function(done){
@@ -224,7 +226,7 @@ module.exports = function(world) {
   });
 
   world.then('I will be taken to summary page', function(done) {
-     clickAndWaitForPage('.summary', /services\/summary/, done);
+     clickAndWaitForPage('.summary', /apply\/summary/, done);
   });
 
   world.then('I will be taken to the political party choose page', function(done){

--- a/test/features/step_definitions/voter-citizen-status-steps.js
+++ b/test/features/step_definitions/voter-citizen-status-steps.js
@@ -49,8 +49,8 @@ module.exports = function(world) {
     .waitForSelector('.citizen-status-form')
     .click('label[for="Yes"]')
     .click('input[type="submit"]')
-    .click('a.home')
-    .waitForSelector('.home-page')
+    .click('a.sections')
+    .waitForSelector('.section-links')
     .then(() => { done(); })
     .catch(done);
   });

--- a/test/features/step_definitions/voter-eligibility-requirements-steps.js
+++ b/test/features/step_definitions/voter-eligibility-requirements-steps.js
@@ -52,8 +52,8 @@ world.given('I have already entered my voter eligibility requirement status into
     .click('a.eligibility-requirements')
     .click('label[for="Yes"]')
     .click('input[type="submit"]')
-    .click('a.home')
-    .waitForSelector('.home-page')
+    .click('a.sections')
+    .waitForSelector('.section-links')
     .then(() => { done(); })
     .catch(done);
 });

--- a/test/features/support/setup.js
+++ b/test/features/support/setup.js
@@ -11,7 +11,7 @@ module.exports = function setup(callback) {
   let browser = new Browser();
 
   function url(path) {
-    let base = `http://localhost:${port}/services`;
+    let base = `http://localhost:${port}/apply`;
     let fullUrl = base;
     if (path && path[0] !== '/') {
       fullUrl = `${fullUrl}/${path}`;


### PR DESCRIPTION
In order to release, we need to have an app that starts with the
introduction page, and flows as we expect through the application.

* This commit changes the react application namespace from `/services`
to `/apply`. The developer directories are organized this way and it
makes more sense.

* It change the server to redirect to the intro page.

* It hides the link to the links page, by making it transparent in
color and setting the tabIndex to -1.

* It changes the acceptance tests to use this back door until we can get
navigation working programatically outside of react.

-------

@teresavshen I think this might fix the story that was rejected that you are working on.