### PR TITLE
Added appropriate names history page

### DIFF
--- a/client/containers/apply/dlid-history-form-container.jsx
+++ b/client/containers/apply/dlid-history-form-container.jsx
@@ -14,7 +14,7 @@ import * as dataPresent                    from '../../helpers/data-present';
 const ConnectedForm = (props) => {
   let continueDisabled                  = !(dataPresent.dlidHistory(props.dlidHistory));
   let showEnterDLidHistory              = false;
-  let onSubmit                          = navigateOnSubmit('/about-me/previous-names', props);
+  let onSubmit                          = navigateOnSubmit('/about-me/names-history/', props);
 
 if(props.dlidHistory.isIssued === 'Yes') {
   showEnterDLidHistory  = false;


### PR DESCRIPTION
- Correction: continue button for license history was going to blank page. Added back names history page.