### PR TITLE
Enables Redux DevTools Chrome Extension

### DIFF
--- a/client/containers/app.jsx
+++ b/client/containers/app.jsx
@@ -7,11 +7,17 @@ import { Provider }                         from "react-redux";
 import { createStore, applyMiddleware }     from "redux";
 import createBrowserHistory                 from 'history/createBrowserHistory'
 import thunk                                from 'redux-thunk';
+import { composeWithDevTools }              from 'redux-devtools-extension/developmentOnly';
 
 import reducers                             from "../reducers";
 import Routes                               from './routes.jsx';
 
-const history = createBrowserHistory()
+const store = createStore(
+  reducers,
+  composeWithDevTools(applyMiddleware(thunk))
+);
+
+const history = createBrowserHistory();
 
 class App extends React.Component {
   constructor() {
@@ -20,7 +26,7 @@ class App extends React.Component {
   }
   render() {
     return (
-      <Provider store={createStore( reducers, applyMiddleware(thunk) )}>
+      <Provider store={store}>
         <Router history={history}>
           <Routes />
         </Router>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3840,14 +3840,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3856,6 +3848,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8547,6 +8547,12 @@
         "symbol-observable": "1.0.4"
       }
     },
+    "redux-devtools-extension": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz",
+      "integrity": "sha1-4Pmo6N/KfBe+kscSSVijuU6ykR0=",
+      "dev": true
+    },
     "redux-thunk": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
@@ -9191,15 +9197,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -9218,6 +9215,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "pg-json-schema-export": "^0.13.7",
     "phantomjs": "^2.1.7",
     "react-test-renderer": "^15.6.1",
+    "redux-devtools-extension": "^2.13.2",
     "sass-loader": "^6.0.5",
     "sinon": "^3.2.1",
     "style-loader": "^0.18.1",


### PR DESCRIPTION
This change allows developers to use the Redux DevTools extension for Chrome. More information about this extension, including installation instructions, can be found at: https://github.com/zalmoxisus/redux-devtools-extension

I really enjoy being able to see redux state evolve over time. 🕶 