### PR TITLE
Ports controller code from oauth branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2566,6 +2566,11 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "crc": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms="
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -3089,6 +3094,11 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -3581,6 +3591,37 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
           "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+        }
+      }
+    },
+    "express-session": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
+      "integrity": "sha512-r0nrHTCYtAMrFwZ0kBzZEXa1vtPVrw0dKvGSrKP4dahwBQ1BJpF2/y1Pp4sCD/0kvxV4zZeclyvfmw0B4RMJQA==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "crc": "3.4.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.2",
+        "uid-safe": "2.1.5",
+        "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "parseurl": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+        },
+        "uid-safe": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+          "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+          "requires": {
+            "random-bytes": "1.0.0"
+          }
         }
       }
     },

--- a/server.js
+++ b/server.js
@@ -39,6 +39,6 @@ server.get('/', (req, res) => {
   res.redirect('/apply/welcome');
 });
 
-server.use('/', routes);
+server.use('/', routes(passport));
 
 module.exports = server;

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const authNew = (passport) => {
+  return passport.authenticate('oauth2', { scope: ['multifactor'] });
+};
+
+const authCallback = (passport) => {
+  return passport.authenticate('oauth2', { failureRedirect: '/auth/error' });
+}
+
+const authSuccess = (req, res) => {
+  req.session.user = req.user; // is this right? or should be use a method in passport to do the serialization?
+  res.redirect('/apply/welcome');
+};
+
+const authError = (req, res) => {
+  // TODO: static page with links to login?
+  console.log('Oauth ID.me failed!');
+}
+
+module.exports = {
+  authNew,
+  authCallback,
+  authSuccess,
+  authError
+};

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -5,9 +5,17 @@ const postApplication   = require('./post-application');
 const getTranslation    = require('./get-translation');
 const renderClient      = require('./render-client');
 
-module.exports = {
+let controllers = {
   getApplication,
   postApplication,
   getTranslation,
   renderClient
 };
+
+const auth = require('./auth');
+
+Object.keys(auth).forEach((authMemberName) => {
+  controllers[authMemberName] = auth[authMemberName];
+});
+
+module.exports = controllers;

--- a/server/routes.js
+++ b/server/routes.js
@@ -3,11 +3,20 @@
 const router            = require('express').Router();
 const controllers       = require('./controllers');
 
-router.get( '/apply*',                controllers.renderClient);
-router.get( '/add*',                  controllers.renderClient);
-router.get( '/api/application/:id',   controllers.getApplication);
-router.post('/api/application',       controllers.postApplication);
-router.post('/api/translation/:code', controllers.getTranslation);
+const routes = (passport) => {
+  router.get( '/apply*',                controllers.renderClient);
+  router.get( '/add*',                  controllers.renderClient);
 
-module.exports = router;
+  router.get( '/api/application/:id',   controllers.getApplication);
+  router.post('/api/application',       controllers.postApplication);
+  router.post('/api/translation/:code', controllers.getTranslation);
+
+  router.get( '/auth/new',              controllers.authNew(passport));
+  router.get( '/auth/oauth/callback',   controllers.authCallback(passport),
+                                        controllers.authSuccess);
+  router.get( '/auth/error',            controllers.authError);
+  return router;
+};
+
+module.exports = routes;
 

--- a/test/server/controllers/auth-test.js
+++ b/test/server/controllers/auth-test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert      = require('assert');
+const sinon       = require('sinon');
+const httpMocks   = require('node-mocks-http');
+const controllers = require('../../../server/controllers/auth');
+
+describe('Auth related controllers', () => {
+  let req, res, passport;
+
+  beforeEach(function() {
+    req = {session: {user: {id: 'foo'}}};
+    res = httpMocks.createResponse({});
+    res.redirect = sinon.spy();
+    passport = { authenticate: sinon.spy() };
+  });
+
+  it('#authNew setups passport for the start of the oauth exchange', function() {
+    controllers.authNew(passport);
+    assert(passport.authenticate.calledWith('oauth2', { scope: ['multifactor'] }));
+  });
+
+  it('#authCallback setups passport for the conclusion of the oauth exchange', function() {
+    controllers.authCallback(passport);
+    assert(passport.authenticate.calledWith('oauth2', { failureRedirect: '/auth/error' }));
+  });
+
+  it('#authSuccess redirects to /apply/welcome', function() {
+    controllers.authSuccess(req, res);
+    assert(res.redirect.calledWith('/apply/welcome'));
+  });
+});


### PR DESCRIPTION
and refactors a bit. This controller code for oauth is working, and is
unit tested. It isn't acceptance tested. Everyone already tried to find
a library that could mock the oauth exchange.

The best I could come up with is to spin up a mock oauth server when we
are in setup for the acceptance tests. Also overwriting the id.me urls
in that test env would be easy now that they are in env vars.

We should make this effort, but after the April deadline. The reason I
don't think we should spend the time now is because it will require a
lot of time digging into the libraries to observer requests and make
sure we are mocking the right oauth calls.