### PR TITLE
Under 18

### DIFF
--- a/client/containers/iddl/organ-donation/organ-donation-form-container.jsx
+++ b/client/containers/iddl/organ-donation/organ-donation-form-container.jsx
@@ -30,6 +30,7 @@ function mapStateToProps(state) {
   return {
     organDonation   : state.application.organDonation,
     dateOfBirth     : state.application.basics.dateOfBirth,
+    DLApp           : state.application.DLApp,
     focused         : state.ui.focus,
     validations     : state.ui.validations,
     flow            : state.ui.flow

--- a/client/containers/iddl/voter-registration/citizen-status-form-container.jsx
+++ b/client/containers/iddl/voter-registration/citizen-status-form-container.jsx
@@ -27,6 +27,7 @@ const Page = (props) => {
 
 const mapStateToProps = (state) => {
   return {
+    DLApp               : state.application.DLApp,
     citizenStatus       : state.application.voting.citizenStatus,
     cardAction          : state.application.cardAction,
     dateOfBirth         : state.application.basics.dateOfBirth,

--- a/client/containers/iddl/voter-registration/eligibility-requirements-form-container.jsx
+++ b/client/containers/iddl/voter-registration/eligibility-requirements-form-container.jsx
@@ -25,6 +25,7 @@ const Page = (props) => {
 
 const mapStateToProps = (state) => {
   return {
+    DLApp                   : state.application.DLApp,
     eligibilityRequirements : state.application.voting.eligibilityRequirements,
     dateOfBirth             : state.application.basics.dateOfBirth,
     focused                 : state.ui.focus,

--- a/client/containers/iddl/voter-registration/opt-out-form-container.jsx
+++ b/client/containers/iddl/voter-registration/opt-out-form-container.jsx
@@ -25,6 +25,7 @@ const Page = (props) => {
 
 const mapStateToProps = (state) => {
   return {
+    DLApp         : state.application.DLApp,
     optOut        : state.application.voting.optOut,
     dateOfBirth   : state.application.basics.dateOfBirth,
     focused       : state.ui.focus,

--- a/client/helpers/data/application.js
+++ b/client/helpers/data/application.js
@@ -30,7 +30,6 @@ export const isProduction = (env = APP_ENV) => {
 };
 
 export function requireLogIn(pathname, isLoggedIn, env = APP_ENV){
-  console.log('check to see if user is logged on: ' + isLoggedIn);
   return (isProduction(env) && !isLoggedIn && afterIntro(pathname));
 };
 

--- a/client/helpers/data/youth.js
+++ b/client/helpers/data/youth.js
@@ -41,7 +41,7 @@ export const isNewDriver = (props) => {
 };
 
 export const requireGuardianSignature = (props) => {
-  return ageChecks.Under18(props) && DLAppExists(props);
+  return ageChecks.Under18(props.dateOfBirth) && DLAppExists(props);
 };
 
 

--- a/client/helpers/data/youth.js
+++ b/client/helpers/data/youth.js
@@ -40,10 +40,13 @@ export const isNewDriver = (props) => {
   return ageChecks.Under18(props.dateOfBirth, props.now) && ageChecks.GreaterThanEqual15Half(props.dateOfBirth, props.now) && props.licenseIssued !== 'Yes';
 };
 
-export const requireGuardianSignature = (props) => {
+export const requireGuardianSignatureUnder18 = (props) => {
   return ageChecks.Under18(props.dateOfBirth) && DLAppExists(props);
 };
 
+export const requireGuardianSignatureUnder16 = (props) => {
+  return ageChecks.Under16(props.dateOfBirth) && DLAppExists(props);
+};
 
 export const needsKnowledgeTest = (props) => {
   return ageChecks.Under17Half(props.dateOfBirth, props.now);

--- a/client/helpers/data/youth.js
+++ b/client/helpers/data/youth.js
@@ -5,7 +5,10 @@ import {
   ageChecks,
   isPreregistering
 } from '../calculate-age';
-import { getDL } from './card-type';
+import {
+  getDL,
+  DLAppExists
+} from './card-type';
 
 export const validToContinue = (props) => {
   return props.youthIDInstead !== 'No' ||
@@ -20,6 +23,7 @@ export const tooYoungForDL = (props) => {
 export const under16GuardianSignature = (props) => {
   return ageChecks.Under16(props.dateOfBirth);
 };
+
 export const checkPreReg = (dateOfBirth) => {
   return isPreregistering(dateOfBirth) ? 'voterPreRegistration' : 'voterRegistration';
 };
@@ -35,6 +39,11 @@ export const continueHidden = (props) => {
 export const isNewDriver = (props) => {
   return ageChecks.Under18(props.dateOfBirth, props.now) && ageChecks.GreaterThanEqual15Half(props.dateOfBirth, props.now) && props.licenseIssued !== 'Yes';
 };
+
+export const requireGuardianSignature = (props) => {
+  return ageChecks.Under18(props) && DLAppExists(props);
+};
+
 
 export const needsKnowledgeTest = (props) => {
   return ageChecks.Under17Half(props.dateOfBirth, props.now);

--- a/client/helpers/handlers/on-logged-in.js
+++ b/client/helpers/handlers/on-logged-in.js
@@ -31,8 +31,7 @@ export default (dispatch) => {
 
     dispatch(getUserData(uuid))
       .then((res) => {
-        console.log('client got response from server: ');
-        console.log(res)
+        console.log('client got response from server');
 
         let userData = res;
         if(res === 'user-fail') {

--- a/client/helpers/navigation/id-dl/organ-donation/next-path.js
+++ b/client/helpers/navigation/id-dl/organ-donation/next-path.js
@@ -1,15 +1,17 @@
 'use strict';
 import { altFlow }                  from '../../../data/pathnames';
-import { requireGuardianSignature } from '../../../data/youth';
+import {
+  requireGuardianSignatureUnder16
+} from '../../../data/youth';
 import { ageChecks }                from '../../../calculate-age';
 
 export const organDonationPath = (props) => {
   let key = 'summary';
   if (!altFlow(props)) {
     key = 'citizenship';
-    if (requireGuardianSignature(props)) {
+    if (requireGuardianSignatureUnder16(props)) {
       key = 'guardianSignature';
-    } else if (ageChecks.Under16(props)) {
+    } else if (ageChecks.Under16(props.dateOfBirth)) {
       key = 'summary';
     }
   }

--- a/client/helpers/navigation/id-dl/organ-donation/next-path.js
+++ b/client/helpers/navigation/id-dl/organ-donation/next-path.js
@@ -1,13 +1,16 @@
 'use strict';
 import { altFlow }                  from '../../../data/pathnames';
-import { under16GuardianSignature } from '../../../data/youth';
+import { requireGuardianSignature } from '../../../data/youth';
+import { ageChecks }                from '../../../calculate-age';
 
 export const organDonationPath = (props) => {
   let key = 'summary';
   if (!altFlow(props)) {
     key = 'citizenship';
-    if (under16GuardianSignature(props)) {
+    if (requireGuardianSignature(props)) {
       key = 'guardianSignature';
+    } else if (ageChecks.Under16(props)) {
+      key = 'summary';
     }
   }
 

--- a/client/helpers/navigation/id-dl/voter-registration/next-path.js
+++ b/client/helpers/navigation/id-dl/voter-registration/next-path.js
@@ -7,14 +7,14 @@ import {
   eligibleForOptOutExist
 } from '../../../data/voting';
 
-import { requireGuardianSignature } from '../../../data/youth';
+import { requireGuardianSignatureUnder18 } from '../../../data/youth';
 
 
 export const citizenship = (props) => {
   let key = 'summary';
   if (eligibleForCitizen(props)) {
     key = 'votingEligibility';
-  } else if (requireGuardianSignature(props)){
+  } else if (requireGuardianSignatureUnder18(props)){
     key = 'guardianSignature';
   }
   return key;
@@ -24,7 +24,7 @@ export const votingEligibility = (props) => {
   let key = 'summary';
   if (eligibilityRequirementsYes(props)) {
     key = 'votingOptOut';
-  } else if (requireGuardianSignature(props)){
+  } else if (requireGuardianSignatureUnder18(props)){
     key = 'guardianSignature';
   }
   return key;
@@ -36,7 +36,7 @@ export const optOut = (props) => {
     key = 'voterPreferences';
   } else if (eligibleForOptOutExist(props)) {
     key = 'voterPreferencesUpdated'
-  } else if (requireGuardianSignature(props)) {
+  } else if (requireGuardianSignatureUnder18(props)) {
     key = 'guardianSignature';
   }
   return key;

--- a/client/helpers/navigation/id-dl/voter-registration/next-path.js
+++ b/client/helpers/navigation/id-dl/voter-registration/next-path.js
@@ -7,13 +7,14 @@ import {
   eligibleForOptOutExist
 } from '../../../data/voting';
 
-import { isPreregistering } from '../../../calculate-age';
+import { requireGuardianSignature } from '../../../data/youth';
+
 
 export const citizenship = (props) => {
   let key = 'summary';
   if (eligibleForCitizen(props)) {
     key = 'votingEligibility';
-  } else if (isPreregistering(props.dateOfBirth)){
+  } else if (requireGuardianSignature(props)){
     key = 'guardianSignature';
   }
   return key;
@@ -23,7 +24,7 @@ export const votingEligibility = (props) => {
   let key = 'summary';
   if (eligibilityRequirementsYes(props)) {
     key = 'votingOptOut';
-  } else if (isPreregistering(props.dateOfBirth)){
+  } else if (requireGuardianSignature(props)){
     key = 'guardianSignature';
   }
   return key;
@@ -35,7 +36,7 @@ export const optOut = (props) => {
     key = 'voterPreferences';
   } else if (eligibleForOptOutExist(props)) {
     key = 'voterPreferencesUpdated'
-  } else if (isPreregistering(props.dateOfBirth)) {
+  } else if (requireGuardianSignature(props)) {
     key = 'guardianSignature';
   }
   return key;

--- a/server/controllers/logout.js
+++ b/server/controllers/logout.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const logout = (req, res) => {
+  console.log('LOGOUT')
   let appName = req.cookies.appName;
-  console.log('going to redirect to sign in for: ' + appName);
   req.logout();
   req.session.destroy();
   if (!appName || appName.length < 1) {
     res.redirect('/apply/choose-language');
   } else {
-    console.log('calling redirect');
     res.redirect(`/apply/${appName}/sign-in`);
   }
 };

--- a/test/client/helpers/data/youth-test.js
+++ b/test/client/helpers/data/youth-test.js
@@ -153,19 +153,19 @@ describe('Data helpers for youth', function() {
     it('returns true if user is under 18 and getting a DL', function() {
       data.dateOfBirth.year = (year - 17).toString();
       data.DLApp = { isApplying : true };
-      assert.equal(requireGuardianSignature(props), true);
+      assert.equal(requireGuardianSignature(data), true);
     });
     it('returns true if user is under 18 and getting a DL and ID', function() {
       data.dateOfBirth.year = (year - 17).toString();
       data.DLApp = { isApplying : true };
       data.IDApp = { isApplying: true };
-      assert.equal(requireGuardianSignature(props), true);
+      assert.equal(requireGuardianSignature(data), true);
     });
     it('returns false if user is under 18 and getting an ID', function() {
       data.dateOfBirth.year = (year - 17).toString();
       data.DLApp = { isApplying : false };
       data.IDApp = { isApplying: true };
-      assert.equal(requireGuardianSignature(props), false);
+      assert.equal(requireGuardianSignature(data), false);
     });
   });
 

--- a/test/client/helpers/data/youth-test.js
+++ b/test/client/helpers/data/youth-test.js
@@ -8,6 +8,7 @@ import {
   checkPreReg,
   continueHidden,
   under16GuardianSignature,
+  requireGuardianSignature,
   isNewDriver,
   needsKnowledgeTest,
   guardianSigned,
@@ -147,6 +148,27 @@ describe('Data helpers for youth', function() {
       assert.equal(under16GuardianSignature(data), false);
     });
   });
+
+  describe('#requireGuardianSignature', function() {
+    it('returns true if user is under 18 and getting a DL', function() {
+      data.dateOfBirth.year = (year - 17).toString();
+      data.DLApp = { isApplying : true };
+      assert.equal(requireGuardianSignature(props), true);
+    });
+    it('returns true if user is under 18 and getting a DL and ID', function() {
+      data.dateOfBirth.year = (year - 17).toString();
+      data.DLApp = { isApplying : true };
+      data.IDApp = { isApplying: true };
+      assert.equal(requireGuardianSignature(props), true);
+    });
+    it('returns false if user is under 18 and getting an ID', function() {
+      data.dateOfBirth.year = (year - 17).toString();
+      data.DLApp = { isApplying : false };
+      data.IDApp = { isApplying: true };
+      assert.equal(requireGuardianSignature(props), false);
+    });
+  });
+
   describe('#isNewDriver', function() {
     it('returns true when user is 16', function() {
       data.dateOfBirth.year = (year - 16).toString();

--- a/test/client/helpers/data/youth-test.js
+++ b/test/client/helpers/data/youth-test.js
@@ -8,7 +8,8 @@ import {
   checkPreReg,
   continueHidden,
   under16GuardianSignature,
-  requireGuardianSignature,
+  requireGuardianSignatureUnder18,
+  requireGuardianSignatureUnder16,
   isNewDriver,
   needsKnowledgeTest,
   guardianSigned,
@@ -149,23 +150,43 @@ describe('Data helpers for youth', function() {
     });
   });
 
-  describe('#requireGuardianSignature', function() {
+  describe('#requireGuardianSignatureUnder18', function() {
     it('returns true if user is under 18 and getting a DL', function() {
       data.dateOfBirth.year = (year - 17).toString();
       data.DLApp = { isApplying : true };
-      assert.equal(requireGuardianSignature(data), true);
+      assert.equal(requireGuardianSignatureUnder18(data), true);
     });
     it('returns true if user is under 18 and getting a DL and ID', function() {
       data.dateOfBirth.year = (year - 17).toString();
       data.DLApp = { isApplying : true };
       data.IDApp = { isApplying: true };
-      assert.equal(requireGuardianSignature(data), true);
+      assert.equal(requireGuardianSignatureUnder18(data), true);
     });
     it('returns false if user is under 18 and getting an ID', function() {
       data.dateOfBirth.year = (year - 17).toString();
       data.DLApp = { isApplying : false };
       data.IDApp = { isApplying: true };
-      assert.equal(requireGuardianSignature(data), false);
+      assert.equal(requireGuardianSignatureUnder18(data), false);
+    });
+  });
+
+  describe('#requireGuardianSignatureUnder16', function() {
+    it('returns true if user is under 16 and getting a DL', function() {
+      data.dateOfBirth.year = (year - 14).toString();
+      data.DLApp = { isApplying : true };
+      assert.equal(requireGuardianSignatureUnder16(data), true);
+    });
+    it('returns true if user is under 16 and getting a DL and ID', function() {
+      data.dateOfBirth.year = (year - 15).toString();
+      data.DLApp = { isApplying : true };
+      data.IDApp = { isApplying: true };
+      assert.equal(requireGuardianSignatureUnder16(data), true);
+    });
+    it('returns false if user is under 16 and getting an ID', function() {
+      data.dateOfBirth.year = (year - 14).toString();
+      data.DLApp = { isApplying : false };
+      data.IDApp = { isApplying: true };
+      assert.equal(requireGuardianSignatureUnder16(data), false);
     });
   });
 

--- a/test/client/helpers/navigation/id-dl/organ-donation-test.js
+++ b/test/client/helpers/navigation/id-dl/organ-donation-test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('assert');
+
+import {
+  organDonationPath
+} from '../../../../../client/helpers/navigation/id-dl/organ-donation/next-path';
+
+const today = new Date();
+
+
+describe('IDDL Organ donation next-path helpers', function() {
+  let data;
+  const under16 = (today.getFullYear() - 15).toString();
+
+  beforeEach(function() {
+    data = {
+      DLApp: {
+        isApplying: true
+      },
+      dateOfBirth: {
+        year: (today.getFullYear() - 40).toString(),
+        month: (today.getMonth()).toString(),
+        day: today.getDate().toString()
+      },
+      flow: ''
+    };
+  });
+
+
+  describe('#organDonationPath', function() {
+    it('returns "summary" if user is editing', function() {
+      data.flow = 'edit';
+      assert.equal(organDonationPath(data), 'summary');
+    });
+    it('returns "summary" if user is adding', function() {
+      data.flow = 'add';
+      assert.equal(organDonationPath(data), 'summary');
+    });
+    it('returns "citizenship" if user is over 16', function() {
+      assert.equal(organDonationPath(data), 'citizenship');
+    });
+    it('returns "guardianSignature" if user is under 16 and getting a DL', function() {
+      data.dateOfBirth.year = under16;
+      assert.equal(organDonationPath(data), 'guardianSignature');
+    });
+    it('returns "summary" if user is under 16 and not getting a DL', function() {
+      data.dateOfBirth.year = under16;
+      data.DLApp.isApplying = false;
+      assert.equal(organDonationPath(data), 'summary');
+    });
+  });
+
+});
+

--- a/test/client/helpers/navigation/id-dl/voter-registration-test.js
+++ b/test/client/helpers/navigation/id-dl/voter-registration-test.js
@@ -50,6 +50,11 @@ describe('Data helpers for determining next path from current page and props in 
         data.dateOfBirth.year = isPrereg;
         assert.equal(citizenship(data), 'guardianSignature');
       });
+      it('returns "summary" if user is not eligible for citizenship and is preregistering for an ID', function() {
+        data.dateOfBirth.year = isPrereg;
+        data.DLApp.isApplying = false;
+        assert.equal(citizenship(data), 'summary');
+      });
     });
 
     describe('##votingEligibility', function() {
@@ -68,6 +73,11 @@ describe('Data helpers for determining next path from current page and props in 
       it('returns "guardianSignature" if user is not eligible for voting and is preregistering', function() {
         data.dateOfBirth.year = isPrereg;
         assert.equal(votingEligibility(data), 'guardianSignature');
+      });
+      it('returns "summary" if user is not eligible for voting and is preregistering for an ID', function() {
+        data.dateOfBirth.year = isPrereg;
+        data.DLApp.isApplying = false;
+        assert.equal(votingEligibility(data), 'summary');
       });
     });
 

--- a/test/client/helpers/navigation/id-dl/voter-registration-test.js
+++ b/test/client/helpers/navigation/id-dl/voter-registration-test.js
@@ -9,14 +9,18 @@ import {
 } from '../../../../../client/helpers/navigation/id-dl/voter-registration/next-path';
 
 const today = new Date();
-const isPrereg = (today.getFullYear() - 17).toString();
+
 
 describe('Data helpers for determining next path from current page and props in voter-registration section', function() {
   let data;
+  const isPrereg = (today.getFullYear() - 17).toString();
   beforeEach(function() {
     data = {
       optOut: '',
       citizenStatus: '',
+      DLApp: {
+        isApplying: true
+      },
       eligibilityRequirements: '',
       dateOfBirth: {
         year: (today.getFullYear() - 40).toString(),
@@ -79,9 +83,14 @@ describe('Data helpers for determining next path from current page and props in 
         data.optOut = 'existing';
         assert.equal(optOut(data), 'voterPreferencesUpdated');
       });
-      it('returns "guardianSignature" if user is preregistering', function() {
+      it('returns "guardianSignature" if user is preregistering and getting a DL', function() {
         data.dateOfBirth.year = isPrereg;
         assert.equal(optOut(data), 'guardianSignature');
+      });
+      it('returns "summary" if user is preregistering and not getting a DL', function() {
+        data.dateOfBirth.year = isPrereg;
+        data.DLApp.isApplying = false;
+        assert.equal(optOut(data), 'summary');
       });
     });
   });

--- a/test/features/step_definitions/enter-date-of-birth-steps.js
+++ b/test/features/step_definitions/enter-date-of-birth-steps.js
@@ -114,9 +114,11 @@ module.exports = function(world) {
 
   world.when('I am under 16 years old', function(done) {
     let d = new Date();
-    let month = d.getMonth();
-    let day = d.getDate();
-    let year = d.getFullYear() - 13;
+
+    var novemberOrLater = d.getMonth() >= 10;
+    var month = novemberOrLater ? (12 - d.getMonth()) : (d.getMonth() + 2);
+    var day = d.getDate() + 1;
+    var year = novemberOrLater ? (d.getFullYear() - 15 ): (d.getFullYear() - 16);
 
     browser
       .type('#month', month.toString())

--- a/test/features/step_definitions/navigation-steps.js
+++ b/test/features/step_definitions/navigation-steps.js
@@ -337,6 +337,9 @@ module.exports = function(world) {
   world.then('I will be on the page for donate contribution', function(done) {
     assertOnPage('.donate-contribution-form', /id-and-license\/about-me\/donate-contribution/, done);
   });
+  world.then('I will be on the page for voter citizen status entry', function(done) {
+    assertOnPage('.citizen-status-form', /id-and-license\/voting-registration\/citizenship/, done);
+  });
 
   world.then('I will be taken to political party page', function(done){
     assertOnPage('.political-party-preference', /id-and-license\/voter\/political-party/, done);
@@ -358,9 +361,6 @@ module.exports = function(world) {
     assertOnPage('.veterans-questionnaire-form', /cdl\/my-history\/veteran/, done);
   });
 
-  world.then('I will be on the page for voter citizen status entry', function(done) {
-    assertOnPage('.citizen-status-form', /id-and-license\/voting-registration\/citizenship/, done);
-  });
   world.then('I will be on the page for ballot by mail', function(done) {
     assertOnPage('.ballot-by-mail-form', /id-and-license\/voting-registration\/vote-by-mail/, done);
   });

--- a/test/features/youth-users.feature
+++ b/test/features/youth-users.feature
@@ -48,10 +48,15 @@ Feature: Happy path for youth users
     And I will also see that I can make an appointment at any time to get my ID
 
 
-  Scenario: I just turned 16 today
+  Scenario: I just turned 16 today and am getting a DL
     Given I go to the new online DL application page
     When I visit the date of birth page
     And Today I turned 16 years old
+    When I click "Next" to continue
+    And I choose to get a new card
+    And I click "Next" to continue
+    And I click on the DL checkbox
+    And I click "Next" to continue
     When I visit voter citizen status page
     Then I will see header for Voting pre-registration
     When I select citizen Yes

--- a/test/features/youth-users.feature
+++ b/test/features/youth-users.feature
@@ -41,14 +41,41 @@ Feature: Happy path for youth users
     And I click to get an ID instead
     And I click "Next" to continue
     Then I will be on the page for choosing real id
+    When I visit the organ donation page
+    And I choose to donate my organs
+    And I choose to contribute
+    When I click "Next" to continue
+    Then I will be on the page with my summary
     When I visit the ID or DL selection page
     And I click on the DL checkbox
     When I go to the page with my summary
     Then I will see a notification at the top letting me know I can't yet come in to complete my DL application
     And I will also see that I can make an appointment at any time to get my ID
 
+  Scenario: I am between 15.5 and 16
+    Given I go to the new online DL application page
+    When I visit the date of birth page
+    And I indicate that I am under 16 years old
+    When I visit the what do you want to do today page
+    And I choose to get a new card
+    And I click "Next" to continue
+    Then I will be on the ID and DL selection page
+    And I click on the DL checkbox
+    When I visit the organ donation page
+    And I choose to donate my organs
+    And I choose to contribute
+    When I click "Next" to continue
+    Then I will be on the page for guardian signature
+    When I visit the ID or DL selection page
+    And I click on the DL checkbox
+    And I click on the ID checkbox
+    When I visit the organ donation page
+    And I choose to donate my organs
+    And I choose to contribute
+    When I click "Next" to continue
+    Then I will be on the page with my summary
 
-  Scenario: I just turned 16 today and am getting a DL
+  Scenario: I just turned 16 today
     Given I go to the new online DL application page
     When I visit the date of birth page
     And Today I turned 16 years old
@@ -57,7 +84,11 @@ Feature: Happy path for youth users
     And I click "Next" to continue
     And I click on the DL checkbox
     And I click "Next" to continue
-    When I visit voter citizen status page
+    When I visit the organ donation page
+    And I choose to donate my organs
+    And I choose to contribute
+    When I click "Next" to continue
+    Then I will be on the page for voter citizen status entry
     Then I will see header for Voting pre-registration
     When I select citizen Yes
     When I click "Next" to continue
@@ -98,3 +129,10 @@ Feature: Happy path for youth users
     When I visit the required documents page
     Then I will see section about new driver requirements
     Then I will see section about knowledge test
+    When I visit the ID or DL selection page
+    And I click on the DL checkbox
+    And I click on the ID checkbox
+    When I visit the voter eligibility requirements page
+    And I change my eligibility requirement
+    When I click "Next" to continue
+    Then I will be on the page with my summary


### PR DESCRIPTION
goal: users under 18 not getting a DL do not need to see the parent/guardian signature page

 
- [ ] replaced the previous voter registration navigation check with a new helper function "requireGuardianSignatureUnder18". Youth users not getting an ID will go to summary instead of parent-guardian page.

- [ ] replaced organ donation navigation with a new helper function "requireGuardianSignatureUnder16". Youth users under 16 getting an ID will go to summary instead of parent-guardian page. Youth users over 18 will go to pre-registration voting section with either an ID or a DL.

- [ ] added unit tests and feature tests

