### PR TITLE
ADA: text fields

### DIFF
--- a/client/presentations/get-started/youth-license-notification-page.jsx
+++ b/client/presentations/get-started/youth-license-notification-page.jsx
@@ -30,6 +30,7 @@ const FormHeader = (props) => {
         tag             = 'h3'
         className       = 'question'
         translationPath = 'intro.youthDlNotificationPage.question'
+        tabIndex        = '0'
       />
     </div>
   );

--- a/client/presentations/number-input.jsx
+++ b/client/presentations/number-input.jsx
@@ -15,7 +15,6 @@ const Label = (props) => {
     <label
       htmlFor         = { props.identifier }
       className       = { props.errorName }
-      aria-labelledby = { props.identifier }
     >
       <div className='unit'>{props.description}</div>
       <ErrorIcon errorClass={ props.errorName } />

--- a/client/presentations/radio-selector.jsx
+++ b/client/presentations/radio-selector.jsx
@@ -19,7 +19,6 @@ const RadioSelector = function(props) {
       <div className='outline-container'>
         <label
           className='row relative radio-selector'
-          htmlFor={id}
           aria-labelledby={props.value}
         >
           <div className='off-screen'>

--- a/client/presentations/text-area.jsx
+++ b/client/presentations/text-area.jsx
@@ -16,7 +16,6 @@ const TextArea = (props) => {
       <label
         htmlFor         = { props.identifier }
         className       = { className }
-        aria-labelledby = { props.identifier }
       >
         <div className='unit'>{ props.description }</div>
         <ErrorIcon errorClass={ className } />

--- a/client/presentations/text-input.jsx
+++ b/client/presentations/text-input.jsx
@@ -31,7 +31,6 @@ const TextInput = (props) => {
       <label
         htmlFor         = { id }
         className       = { className }
-        aria-labelledby = { id }
       >
         <ErrorIcon
           errorClass={ className }

--- a/client/presentations/voter-registration/introduction/introduction.jsx
+++ b/client/presentations/voter-registration/introduction/introduction.jsx
@@ -12,13 +12,11 @@ const VoterIntro = (props) => {
       <Translator
         tag               = 'h2'
         translationPath   = 'votingRegistration.introductionPage.pagePrompt'
-        tabIndex          = '0'
       />
 
       <Translator
         tag               = 'p'
         translationPath   = 'votingRegistration.introductionPage.explanation'
-        tabIndex          = '0'
       />
 
     </div>

--- a/client/presentations/voter-registration/introduction/stop-citizens-only.jsx
+++ b/client/presentations/voter-registration/introduction/stop-citizens-only.jsx
@@ -15,7 +15,6 @@ const StopCitizensOnly = (props) => {
         tag               = 'h5'
         className         = 'unit'
         translationPath   = 'votingRegistration.introductionPage.citizenOnlyDisclaimer'
-        tabIndex          = '0'
       />
       <hr className='last-unit mid-line' />
     </div>


### PR DESCRIPTION
- Screen readers reads text inputs as blank
- Resolved by using either htmlFor or arial-labeledby; issues when using both.